### PR TITLE
double quote no space json

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ runs:
       shell: bash
     - name: Git diff
       run: |
-        pwd1
+        pwd
         echo $GITHUB_WORKSPACE
         git status
         git diff --name-only "remotes/origin/${{ inputs.comparing_branch }}"

--- a/action.yaml
+++ b/action.yaml
@@ -42,8 +42,6 @@ runs:
       run: |
         pwd
         echo $GITHUB_WORKSPACE
-        git status
-        git branch -a
         git diff --name-only "remotes/origin/${{ inputs.comparing_branch }}"
       shell: bash
     - name: Run Python script

--- a/action.yaml
+++ b/action.yaml
@@ -40,8 +40,9 @@ runs:
       shell: bash
     - name: Git diff
       run: |
-        pwd
+        pwd1
         echo $GITHUB_WORKSPACE
+        git status
         git diff --name-only "remotes/origin/${{ inputs.comparing_branch }}"
       shell: bash
     - name: Run Python script

--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,7 @@ runs:
         pwd
         echo $GITHUB_WORKSPACE
         git status
+        git branch -a
         git diff --name-only "remotes/origin/${{ inputs.comparing_branch }}"
       shell: bash
     - name: Run Python script

--- a/src/main.py
+++ b/src/main.py
@@ -119,19 +119,27 @@ folders_sorted_alpha_dec = sorted(distinct_folders, reverse=True)
 folders_sorted_meta_inc = sorted(folders_with_metadata, key=lambda x: metadata[x])
 folders_sorted_meta_dec = sorted(folders_with_metadata, key=lambda x: metadata[x], reverse=True)
 
-print(f"folders_sorted_alpha_inc: {json.dumps(folders_sorted_alpha_inc)}")
-print(f"folders_sorted_alpha_dec: {json.dumps(folders_sorted_alpha_dec)}}")
-print(f"folders_sorted_meta_inc: {json.dumps(folders_sorted_meta_inc)}}")
-print(f"folders_sorted_meta_dec: {json.dumps(folders_sorted_meta_dec)}}")
+distinct_folders_str = json.dumps(distinct_folders).replace(" ", "")
+folders_with_metadata_str = json.dumps(folders_with_metadata).replace(" ", "")
+folders_without_metadata_str = json.dumps(folders_without_metadata).replace(" ", "")
+folders_sorted_alpha_inc_str = json.dumps(folders_sorted_alpha_inc).replace(" ", "")
+folders_sorted_alpha_dec_str = json.dumps(folders_sorted_alpha_dec).replace(" ", "")
+folders_sorted_meta_inc_str = json.dumps(folders_sorted_meta_inc).replace(" ", "")
+folders_sorted_meta_dec_str = json.dumps(folders_sorted_meta_dec).replace(" ", "")
+
+print(f"folders_sorted_alpha_inc: {folders_sorted_alpha_inc_str}")
+print(f"folders_sorted_alpha_dec: {folders_sorted_alpha_dec_str}")
+print(f"folders_sorted_meta_inc: {folders_sorted_meta_inc_str}")
+print(f"folders_sorted_meta_dec: {folders_sorted_meta_dec_str}")
 
 # Set Outputs
-set_output("distinct_folders", json.dumps(distinct_folders))
-set_output("folders_with_metadata", json.dumps(folders_with_metadata))
-set_output("folders_without_metadata", json.dumps(folders_without_metadata))
-set_output("folders_sorted_alpha_inc", json.dumps(folders_sorted_alpha_inc))
-set_output("folders_sorted_alpha_dec", json.dumps(folders_sorted_alpha_dec))
-set_output("folders_sorted_meta_inc", json.dumps(folders_sorted_meta_inc))
-set_output("folders_sorted_meta_dec", json.dumps(folders_sorted_meta_dec))
+set_output("distinct_folders", distinct_folders_str)
+set_output("folders_with_metadata", folders_with_metadata_str)
+set_output("folders_without_metadata", folders_without_metadata_str)
+set_output("folders_sorted_alpha_inc", folders_sorted_alpha_inc_str)
+set_output("folders_sorted_alpha_dec", folders_sorted_alpha_dec_str)
+set_output("folders_sorted_meta_inc", folders_sorted_meta_inc_str)
+set_output("folders_sorted_meta_dec", folders_sorted_meta_dec_str)
 
 # Convert lists to JSON
 json = json.dumps({

--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,7 @@ except Exception as e:
     git_diff_output = []
 
 # Extract distinct folders
-distinct_folders = list(set([os.path.dirname(path) for path in git_diff_output if path]))
+distinct_folders = list(set([os.path.dirname(path) for path in git_diff_output if path.strip()]))
 print(f"distinct_folders: {distinct_folders}")
 
 # Populate metadata dictionary by reading YAML files in each folder

--- a/src/main.py
+++ b/src/main.py
@@ -110,8 +110,6 @@ for folder in distinct_folders:
     except Exception as e:
         logging.error(f"An error occurred while reading YAML for folder {folder}: {e}")
 
-print(f"folders_with_metadata: {folders_with_metadata}")
-print(f"folders_without_metadata: {folders_without_metadata}")
 
 # Sort folders
 folders_sorted_alpha_inc = sorted(distinct_folders)
@@ -127,6 +125,9 @@ folders_sorted_alpha_dec_str = json.dumps(folders_sorted_alpha_dec).replace(" ",
 folders_sorted_meta_inc_str = json.dumps(folders_sorted_meta_inc).replace(" ", "")
 folders_sorted_meta_dec_str = json.dumps(folders_sorted_meta_dec).replace(" ", "")
 
+print(f"distinct_folders: {distinct_folders_str}")
+print(f"folders_with_metadata: {folders_with_metadata_str}")
+print(f"folders_without_metadata: {folders_without_metadata_str}")
 print(f"folders_sorted_alpha_inc: {folders_sorted_alpha_inc_str}")
 print(f"folders_sorted_alpha_dec: {folders_sorted_alpha_dec_str}")
 print(f"folders_sorted_meta_inc: {folders_sorted_meta_inc_str}")

--- a/src/main.py
+++ b/src/main.py
@@ -119,19 +119,19 @@ folders_sorted_alpha_dec = sorted(distinct_folders, reverse=True)
 folders_sorted_meta_inc = sorted(folders_with_metadata, key=lambda x: metadata[x])
 folders_sorted_meta_dec = sorted(folders_with_metadata, key=lambda x: metadata[x], reverse=True)
 
-print(f"folders_sorted_alpha_inc: {folders_sorted_alpha_inc}")
-print(f"folders_sorted_alpha_dec: {folders_sorted_alpha_dec}")
-print(f"folders_sorted_meta_inc: {folders_sorted_meta_inc}")
-print(f"folders_sorted_meta_dec: {folders_sorted_meta_dec}")
+print(f"folders_sorted_alpha_inc: {json.dumps(folders_sorted_alpha_inc)}")
+print(f"folders_sorted_alpha_dec: {json.dumps(folders_sorted_alpha_dec)}}")
+print(f"folders_sorted_meta_inc: {json.dumps(folders_sorted_meta_inc)}}")
+print(f"folders_sorted_meta_dec: {json.dumps(folders_sorted_meta_dec)}}")
 
 # Set Outputs
-set_output("distinct_folders", distinct_folders)
-set_output("folders_with_metadata", folders_with_metadata)
-set_output("folders_without_metadata", folders_without_metadata)
-set_output("folders_sorted_alpha_inc", folders_sorted_alpha_inc)
-set_output("folders_sorted_alpha_dec", folders_sorted_alpha_dec)
-set_output("folders_sorted_meta_inc", folders_sorted_meta_inc)
-set_output("folders_sorted_meta_dec", folders_sorted_meta_dec)
+set_output("distinct_folders", json.dumps(distinct_folders))
+set_output("folders_with_metadata", json.dumps(folders_with_metadata))
+set_output("folders_without_metadata", json.dumps(folders_without_metadata))
+set_output("folders_sorted_alpha_inc", json.dumps(folders_sorted_alpha_inc))
+set_output("folders_sorted_alpha_dec", json.dumps(folders_sorted_alpha_dec))
+set_output("folders_sorted_meta_inc", json.dumps(folders_sorted_meta_inc))
+set_output("folders_sorted_meta_dec", json.dumps(folders_sorted_meta_dec))
 
 # Convert lists to JSON
 json = json.dumps({


### PR DESCRIPTION
this PR ensures that JSON outputs have double quotes as opposed to single quotes and no spaces. This makes it easier to pass these outputs as input arguments to programs in bash scripts.

keep in mind this will make action throw error if output file paths have spaces